### PR TITLE
Fix IE issue when hack for min-height in vh is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
   function getScrollbarSize() {
     if (typeof scrollbarSize !== 'undefined') return scrollbarSize;
 
-    var doc = document.documentElement;
+    var doc = document.body || document.documentElement;
     var dummyScroller = document.createElement('div');
     dummyScroller.setAttribute('style', 'width:99px;height:99px;' + 'position:absolute;top:-9999px;overflow:scroll;');
     doc.appendChild(dummyScroller);
@@ -16,12 +16,12 @@
   }
 
   function hasScrollbar() {
-    return document.documentElement.scrollHeight > window.innerHeight;
+    return (document.body || document.documentElement).scrollHeight > window.innerHeight;
   }
 
   function on(options) {
     if (typeof document === 'undefined') return;
-    var doc = document.documentElement;
+    var doc = document.body || document.documentElement;
     scrollTop = window.pageYOffset;
     if (hasScrollbar()) {
       doc.style.width = 'calc(100% - '+ getScrollbarSize() +'px)';
@@ -36,7 +36,7 @@
 
   function off() {
     if (typeof document === 'undefined') return;
-    var doc = document.documentElement;
+    var doc = document.body || document.documentElement;
     doc.style.width = '';
     doc.style.position = '';
     doc.style.top = '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "no-scroll",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Disable the document's scrolling",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When vh unit is used for min-height in Internet Explorer, a common hack is used to make it work: set the height to any arbitrary value. See https://stackoverflow.com/questions/25177791/ie11-flexbox-and-vh-height-units-not-compatible.

Now, with that hack in place, style set by no-scroll in HTMLHtmlElement (document.documentElement) doesn't work. However, it works fine if set in the HTMLBodyElement (document.body).

This change solves that issue.