### PR TITLE
set document height to scrollHeight while locked

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@
     } else {
       doc.style.width = '100%';
     }
+    doc.style.height = doc.scrollHeight + 'px';
     doc.style.position = 'fixed';
     doc.style.top = -scrollTop + 'px';
     doc.style.overflow = 'hidden';
@@ -38,6 +39,7 @@
     if (typeof document === 'undefined' || !isOn) return;
     var doc = document.documentElement;
     doc.style.width = '';
+    doc.style.height = '';
     doc.style.position = '';
     doc.style.top = '';
     doc.style.overflow = '';


### PR DESCRIPTION
Just ran into this at work. If you use ```html { height: 100%; }```, it will clip the content since it is now `position: fixed`. This is easily fixed by making sure the `document.documentElement` is set to its `scrollHeight`.

**Before:**

![image](https://user-images.githubusercontent.com/2762082/42351124-2e1f8122-8068-11e8-80a9-d2b0e02986fa.png)

**After:**
![image](https://user-images.githubusercontent.com/2762082/42351163-68af4c3c-8068-11e8-95ef-1b6ea2f8d3e8.png)

